### PR TITLE
Feat/#1/security config 카카오 소셜 로그인 구현 및 시큐리티 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.properties ###
+**/resources/*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.2'
+	id 'org.springframework.boot' version '3.3.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,17 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
@@ -32,4 +32,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
         return new ApiResponse<>(false, code, message, data);
     }
+    public static ApiResponse<Void> onFailure(String code, String message){
+        return new ApiResponse<>(false, code, message, null);
+    }
 }

--- a/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
@@ -1,4 +1,35 @@
 package com.example.SucceSS.apiPayload;
 
-public class ApiResponse {
+import com.example.SucceSS.apiPayload.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@Builder
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    private T result;
+
+
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
 }

--- a/src/main/java/com/example/SucceSS/apiPayload/BaseCode.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/BaseCode.java
@@ -1,0 +1,9 @@
+package com.example.SucceSS.apiPayload;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.SucceSS.apiPayload;
+
+import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.apiPayload.status.ErrorStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+
+    @ExceptionHandler(MemberNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public ApiResponse<Void> handleMemberNotFoundException(MemberNotFound ex) {
+        return ApiResponse.<Void>builder()
+                .isSuccess(false)
+                .code(ErrorStatus._NOT_FOUND.toString())
+                .message(ex.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/GlobalExceptionHandler.java
@@ -1,25 +1,36 @@
 package com.example.SucceSS.apiPayload;
 
 import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
+import com.example.SucceSS.apiPayload.exception.NoBearerException;
 import com.example.SucceSS.apiPayload.status.ErrorStatus;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.slf4j.Logger;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final  Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(MemberNotFound.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(RuntimeException.class)
     @ResponseBody
-    public ApiResponse<Void> handleMemberNotFoundException(MemberNotFound ex) {
-        return ApiResponse.<Void>builder()
-                .isSuccess(false)
-                .code(ErrorStatus._NOT_FOUND.toString())
-                .message(ex.getMessage())
-                .build();
+    public ResponseEntity<ApiResponse<Void>> handleAllExceptions(Exception ex) {
+        HttpStatus status = findHttpStatus(ex);
+        logger.error("Exception: {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+
+        return ResponseEntity.status(status)
+                .body(ApiResponse.onFailure(status.toString(), ex.getMessage()));
     }
+
+    private HttpStatus findHttpStatus(Exception ex) {
+        ResponseStatus responseStatus = ex.getClass().getAnnotation(ResponseStatus.class);
+        return (responseStatus != null) ? responseStatus.value() : HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
 }

--- a/src/main/java/com/example/SucceSS/apiPayload/ReasonDTO.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/ReasonDTO.java
@@ -1,0 +1,17 @@
+package com.example.SucceSS.apiPayload;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/exception/MemberNotFound.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/exception/MemberNotFound.java
@@ -1,0 +1,7 @@
+package com.example.SucceSS.apiPayload.exception;
+
+public class MemberNotFound extends RuntimeException{
+    public MemberNotFound() {
+        super("사용자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/exception/MemberNotFound.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/exception/MemberNotFound.java
@@ -1,5 +1,9 @@
 package com.example.SucceSS.apiPayload.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class MemberNotFound extends RuntimeException{
     public MemberNotFound() {
         super("사용자를 찾을 수 없습니다.");

--- a/src/main/java/com/example/SucceSS/apiPayload/exception/NoAuthorizationHeaderException.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/exception/NoAuthorizationHeaderException.java
@@ -1,0 +1,11 @@
+package com.example.SucceSS.apiPayload.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class NoAuthorizationHeaderException extends RuntimeException{
+    public NoAuthorizationHeaderException() {
+        super("Authorization header가 존재하지 않습니다");
+    }
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/exception/NoBearerException.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/exception/NoBearerException.java
@@ -1,0 +1,11 @@
+package com.example.SucceSS.apiPayload.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class NoBearerException extends RuntimeException{
+    public NoBearerException() {
+        super("Bearer 토큰이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/status/ErrorStatus.java
@@ -13,7 +13,13 @@ public enum ErrorStatus implements BaseCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-    _NOT_FOUND(HttpStatus.NOT_FOUND,"COMMON404","해당 경로에 맞는 리소스를 찾을 수 없습니다");
+    _NOT_FOUND(HttpStatus.NOT_FOUND,"COMMON404","해당 경로에 맞는 리소스를 찾을 수 없습니다"),
+    _EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"EXPIRE_401","토큰이 만료되었습니다."),
+    _SIGNATURE(HttpStatus.UNAUTHORIZED,"SIGNATURE_401","잘못된 서명입니다"),
+    _MALFORMED(HttpStatus.UNAUTHORIZED,"MALFORMED_401","잘못된 형식입니다"),
+    _NO_HEADER(HttpStatus.UNAUTHORIZED,"NO_HEADER_401","인증 헤더가 존재하지 않습니다"),
+    _BEARER(HttpStatus.UNAUTHORIZED,"NO_BEARER_401","Bearer 형식이 올바르지 않습니다."),
+    _LOGOUT(HttpStatus.UNAUTHORIZED,"LOGOUT_401","로그아웃 된 토큰입니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/SucceSS/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/status/ErrorStatus.java
@@ -1,0 +1,40 @@
+package com.example.SucceSS.apiPayload.status;
+
+import com.example.SucceSS.apiPayload.BaseCode;
+import com.example.SucceSS.apiPayload.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorStatus implements BaseCode {
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND,"COMMON404","해당 경로에 맞는 리소스를 찾을 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/SucceSS/apiPayload/status/SuccessStatus.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/status/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.example.SucceSS.apiPayload.status;
+
+import com.example.SucceSS.apiPayload.BaseCode;
+import com.example.SucceSS.apiPayload.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    _OK(HttpStatus.OK, "2000", "Ok"),;
+
+    private HttpStatus httpStatus;
+    private String code;
+
+    private String message;
+
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .code(message)
+                .message(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .code(message)
+                .message(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/SwaggerConfig.java
+++ b/src/main/java/com/example/SucceSS/config/SwaggerConfig.java
@@ -1,4 +1,26 @@
 package com.example.SucceSS.config;
 
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
 public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI(){
+        SecurityScheme AccessToken = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", AccessToken))
+                .security(Arrays.asList(securityRequirement));
+    }
 }

--- a/src/main/java/com/example/SucceSS/config/WebConfig.java
+++ b/src/main/java/com/example/SucceSS/config/WebConfig.java
@@ -1,4 +1,14 @@
 package com.example.SucceSS.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
 public class WebConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/com/example/SucceSS/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/SucceSS/config/security/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.example.SucceSS.config.security;
+
+import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return createUserDetails(memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFound::new));
+    }
+
+    public UserDetails createUserDetails(Member member) {
+        UserDetails userDetails =  org.springframework.security.core.userdetails.User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .authorities(new SimpleGrantedAuthority(member.getUserRole().toString()))
+                .build();
+        return userDetails;
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/SucceSS/config/security/CustomUserDetailsService.java
@@ -18,15 +18,15 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return createUserDetails(memberRepository.findByEmail(email)
+    public UserDetails loadUserByUsername(String socialId) throws UsernameNotFoundException {
+        return createUserDetails(memberRepository.findBySocialId(socialId)
                 .orElseThrow(MemberNotFound::new));
     }
 
     public UserDetails createUserDetails(Member member) {
         UserDetails userDetails =  org.springframework.security.core.userdetails.User.builder()
-                .username(member.getEmail())
-                .password(member.getPassword())
+                .username(member.getSocialId())
+                .password(passwordEncoder.encode("KAKAO"))
                 .authorities(new SimpleGrantedAuthority(member.getUserRole().toString()))
                 .build();
         return userDetails;

--- a/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,16 @@
+package com.example.SucceSS.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationEntryPoint.java
@@ -1,16 +1,51 @@
 package com.example.SucceSS.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 import java.io.IOException;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationEntryPoint.class);
+    private final static String EXCEPTION = "exception";
+    private final static String LOGOUT = "logout";
+    private final static String MALFORMED = "malformed";
+    private final static String EXPIRED = "expired";
+    private final static String HEADER = "header";
+    private final static String BEARER = "bearer";
 
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        String exception = (String)request.getAttribute(EXCEPTION);
+        response.setContentType("application/json; charset=UTF-8");
+        logger.error("인증 실패 - 예외 발생: {}, 원인: {}", request.getAttribute("EXCEPTION"), authException.getMessage(), authException);
+
+        if(exception!=null) {
+            switch (exception) {
+                case EXPIRED -> setResponse(response, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다");
+                case MALFORMED -> setResponse(response, HttpStatus.BAD_REQUEST.value(), "잘못된 형식의 토큰입니다");
+                case HEADER -> setResponse(response, HttpStatus.BAD_REQUEST.value(), "Authorization 헤더가 존재하지 않습니다.");
+                case LOGOUT -> setResponse(response, HttpStatus.BAD_REQUEST.value(), "로그아웃 처리된 토큰입니다.");
+                case BEARER -> setResponse(response, HttpStatus.BAD_REQUEST.value(), "Bearer 형식이 잘못됐습니다.");
+            }
+        }
+    }
+    public void setResponse(HttpServletResponse response,int status,String msg) throws IOException {
+        ObjectNode json = new ObjectMapper().createObjectNode();
+        json.put("status",status);
+        json.put("success", false);
+        json.put("message", msg);
+        String newResponse = new ObjectMapper().writeValueAsString(json);
+        response.getWriter().write(newResponse);
+        response.setStatus(status);
     }
 }

--- a/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.example.SucceSS.config.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final static String EXCEPTION = "exception";
+    private final static String LOGOUT = "logout";
+    private final static String MALFORMED = "malformed";
+    private final static String EXPIRED = "expired";
+    private final static String HEADER = "header";
+    private final static String BEARER = "bearer";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String token = resolveToken(request);
+
+            if (jwtProvider.validateToken(token)) {
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (MalformedJwtException e) {
+            request.setAttribute(EXCEPTION,MALFORMED);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute(EXCEPTION, EXPIRED);
+        } finally {
+            filterChain.doFilter(request, response);
+        }
+
+    }
+
+    //헤더에서 토큰 정보 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        /*
+        if(!StringUtils.hasText(bearerToken)) throw new NoAuthorizationHeaderException();
+        if(!bearerToken.startsWith("Bearer")) throw new NoBearerException();
+         */
+        return bearerToken.substring(7);
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.example.SucceSS.config.security;
 
+import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
+import com.example.SucceSS.apiPayload.exception.NoBearerException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
@@ -38,6 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             request.setAttribute(EXCEPTION,MALFORMED);
         } catch (ExpiredJwtException e) {
             request.setAttribute(EXCEPTION, EXPIRED);
+        } catch (NoAuthorizationHeaderException e) {
+            request.setAttribute(EXCEPTION, HEADER);
+        } catch (NoBearerException e) {
+            request.setAttribute(EXCEPTION,BEARER);
         } finally {
             filterChain.doFilter(request, response);
         }
@@ -47,10 +53,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     //헤더에서 토큰 정보 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        /*
+
         if(!StringUtils.hasText(bearerToken)) throw new NoAuthorizationHeaderException();
         if(!bearerToken.startsWith("Bearer")) throw new NoBearerException();
-         */
+
         return bearerToken.substring(7);
     }
 }

--- a/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
 import com.example.SucceSS.apiPayload.exception.NoBearerException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final static String EXPIRED = "expired";
     private final static String HEADER = "header";
     private final static String BEARER = "bearer";
+    private final static String SIGNATURE = "signature";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -37,13 +39,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (MalformedJwtException e) {
-            request.setAttribute(EXCEPTION,MALFORMED);
+            request.setAttribute(EXCEPTION, MALFORMED);
         } catch (ExpiredJwtException e) {
             request.setAttribute(EXCEPTION, EXPIRED);
         } catch (NoAuthorizationHeaderException e) {
             request.setAttribute(EXCEPTION, HEADER);
         } catch (NoBearerException e) {
-            request.setAttribute(EXCEPTION,BEARER);
+            request.setAttribute(EXCEPTION, BEARER);
+        } catch(SignatureException e) {
+            request.setAttribute(EXCEPTION, SIGNATURE);
         } finally {
             filterChain.doFilter(request, response);
         }

--- a/src/main/java/com/example/SucceSS/config/security/JwtProvider.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtProvider.java
@@ -1,0 +1,94 @@
+package com.example.SucceSS.config.security;
+
+import com.example.SucceSS.web.dto.TokenDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtProvider {
+    //access token 유효기간
+    private final long EXPIRE_TIME_ACCESS = 1000 * 60 * 60; //1시간
+    private final long EXPIRE_TIME_REFRESH = 1000 * 60 * 60 * 24 * 7; //1주일
+    private final SecretKey key;
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+    }
+
+    public TokenDto generateToken(Authentication authentication) {
+        //사용자 권한정보
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        //access token expire time
+        long now = (new Date()).getTime();
+        Date AccessTokenExpireTime = new Date(now+EXPIRE_TIME_ACCESS);
+        //access token 생성
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth",authorities)
+                .setExpiration(AccessTokenExpireTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+        //refresh token 생성
+        Date refreshTokenExpireTime = new Date(now + EXPIRE_TIME_REFRESH);
+        String refreshToken = Jwts.builder()
+                .setExpiration(refreshTokenExpireTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public boolean validateToken(String token) {
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        return true;
+    }
+
+    public Authentication getAuthentication(String token) {
+        // 토큰 복호화
+        Claims claims = parseClaims(token);
+        if (claims.get("auth") == null) {
+            //throw new NoAuthAccessTokenException();
+        }
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+        UserDetails userDetails = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+    }
+
+    public Claims parseClaims(String accessToken) {
+        //reissue 하는 경우에 토큰 관련 exception은 여기서 걸림
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException("잘못된 형식의 토큰입니다");
+        }
+    }
+    public Long getExpiration(String bearerToken) {
+        return parseClaims(bearerToken).getExpiration().getTime()-(new Date()).getTime();
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
@@ -18,16 +18,20 @@ public class SecurityConfig {
 
 
     private final String[] WHITE_LIST = new String[]{
-            "/swagger-ui/index.html",
-            "/swagger-ui/index.html#/"
-            ,"/swagger-ui.html"
-            ,"/swagger-ui/**"
-            ,"/api-docs/**"
-            ,"/v3/api-docs/**",
             "/api/auth/sign-up/**",
-            "/api/auth/sign-in",
+            "/api/auth/sign-in/**",
             "/error",
             "/api/auth/reissue"
+    };
+    private static final String[] SWAGGER_WHITELIST = {
+            "/swagger-ui/**", "/v3/api-docs/**"
+            ,"/swagger-ui.html"
+            ,"/swagger-ui/**"
+            ,"/api-docs/**",
+            "/v3/api-docs/**",
+            "v3/api-docs/**",
+            "/swagger-ui/**",
+            "swagger-ui/**"
     };
 
     @Bean
@@ -39,6 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeRequests)->
                         authorizeRequests
                                 .requestMatchers(WHITE_LIST).permitAll()
+                                .requestMatchers(SWAGGER_WHITELIST).permitAll()
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated())
                 .exceptionHandling((exception) ->

--- a/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.example.SucceSS.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+
+
+    private final String[] WHITE_LIST = new String[]{
+            "/swagger-ui/index.html",
+            "/swagger-ui/index.html#/"
+            ,"/swagger-ui.html"
+            ,"/swagger-ui/**"
+            ,"/api-docs/**"
+            ,"/v3/api-docs/**",
+            "/api/auth/sign-up/**",
+            "/api/auth/sign-in",
+            "/error",
+            "/api/auth/reissue"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement)->sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((authorizeRequests)->
+                        authorizeRequests
+                                .requestMatchers(WHITE_LIST).permitAll()
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                .anyRequest().authenticated())
+                .exceptionHandling((exception) ->
+                        exception.authenticationEntryPoint(new JwtAuthenticationEntryPoint()))
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/SucceSS/domain/Member.java
+++ b/src/main/java/com/example/SucceSS/domain/Member.java
@@ -16,16 +16,14 @@ import org.antlr.v4.runtime.misc.NotNull;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="user_id")
+    @Column(name="member_id")
     private Long id;
 
+    @Column(name="social_id", unique = true)
+    private String socialId;
     @NotNull
-    private String email;
-    @NotNull
-    private String password;
-    @NotNull
-    @Column(name = "user_name")
-    private String userName;
+    @Column(name = "nickname")
+    private String nickname;
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name="user_role")

--- a/src/main/java/com/example/SucceSS/domain/Member.java
+++ b/src/main/java/com/example/SucceSS/domain/Member.java
@@ -1,4 +1,33 @@
 package com.example.SucceSS.domain;
 
+import com.example.SucceSS.domain.common.Role;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_id")
+    private Long id;
+
+    @NotNull
+    private String email;
+    @NotNull
+    private String password;
+    @NotNull
+    @Column(name = "user_name")
+    private String userName;
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name="user_role")
+    private Role userRole;
 }

--- a/src/main/java/com/example/SucceSS/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/SucceSS/domain/common/BaseEntity.java
@@ -1,4 +1,25 @@
 package com.example.SucceSS.domain.common;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/SucceSS/domain/common/Role.java
+++ b/src/main/java/com/example/SucceSS/domain/common/Role.java
@@ -1,0 +1,5 @@
+package com.example.SucceSS.domain.common;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/example/SucceSS/repository/MemberRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/MemberRepository.java
@@ -1,4 +1,13 @@
 package com.example.SucceSS.repository;
 
-public class MemberRepository {
+import com.example.SucceSS.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/SucceSS/repository/MemberRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/MemberRepository.java
@@ -8,6 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-    boolean existsByEmail(String email);
+    Optional<Member> findBySocialId(String socialId);
 }

--- a/src/main/java/com/example/SucceSS/service/MemberService/AuthService.java
+++ b/src/main/java/com/example/SucceSS/service/MemberService/AuthService.java
@@ -1,0 +1,56 @@
+package com.example.SucceSS.service.MemberService;
+
+import com.example.SucceSS.config.security.JwtProvider;
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.repository.MemberRepository;
+import com.example.SucceSS.web.dto.KakaoAccountDto;
+import com.example.SucceSS.web.dto.TokenDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final KakaoService kakaoService;
+    private final JwtProvider jwtProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Transactional
+    public TokenDto signIn(String code) {
+        KakaoAccountDto userInfo = kakaoService.getUserInfo(code);
+        Member member = memberRepository.findBySocialId(userInfo.getId().toString())
+                .orElseGet(()->saveMember(userInfo));
+
+        Authentication authentication = setAuthentication(member.getSocialId(), "KAKAO");
+        System.out.println("done setting authentication");
+        TokenDto tokenDto = jwtProvider.generateToken(authentication);
+        return tokenDto;
+    }
+
+    @Transactional
+    public Member saveMember(KakaoAccountDto dto) {
+        Member member = KakaoAccountDto.toMemberEntity(dto);
+        return memberRepository.save(member);
+    }
+
+
+    private Authentication setAuthentication(String socialId, String password) {
+        UsernamePasswordAuthenticationToken usernamePasswordAuth = new UsernamePasswordAuthenticationToken(socialId, password);
+        System.out.println("done getting UsernamePasswordAuthenticationToken");
+        //customUserDetails -> loadUserByUsername 호출 : 실제 검증 수행
+        System.out.println(usernamePasswordAuth.getName()+", "+usernamePasswordAuth.getCredentials());
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(usernamePasswordAuth);
+        System.out.println("getting context");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return authentication;
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/service/MemberService/KakaoService.java
+++ b/src/main/java/com/example/SucceSS/service/MemberService/KakaoService.java
@@ -1,0 +1,53 @@
+package com.example.SucceSS.service.MemberService;
+
+import com.example.SucceSS.web.dto.KakaoAccountDto;
+import com.example.SucceSS.web.dto.KakaoTokenDto;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class KakaoService {
+
+    private static final String KAKAO_OAUTH_URL = "https://kauth.kakao.com";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com";
+    @Value("${kakao.redirect.uri}") private String REDIRECT_URI;
+    @Value("${kakao.client.id}") private String clientId;
+    public KakaoAccountDto getUserInfo(String code) {
+        String accessToken = getAccessToken(code);
+        KakaoAccountDto userInfo = WebClient.create(KAKAO_USER_INFO_URL).get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/v2/user/me")
+                        .queryParam("property_keys", "[\"kakao_account.profile\"]")
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .bodyToMono(KakaoAccountDto.class).block();
+        return userInfo;
+    }
+    private String getAccessToken(String code) {
+        KakaoTokenDto kakaoTokenDto = WebClient.create(KAKAO_OAUTH_URL).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", REDIRECT_URI)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //Exception 처리
+                //.onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                //동기식으로 response의 body 가져와서 dto에 매핑
+                .bodyToMono(KakaoTokenDto.class).block();
+        return kakaoTokenDto.getAccessToken();
+    }
+}

--- a/src/main/java/com/example/SucceSS/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/SucceSS/service/MemberService/MemberService.java
@@ -1,4 +1,7 @@
 package com.example.SucceSS.service.MemberService;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class MemberService {
 }

--- a/src/main/java/com/example/SucceSS/web/controller/AuthController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.example.SucceSS.web.controller;
+
+import com.example.SucceSS.apiPayload.ApiResponse;
+import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.service.MemberService.AuthService;
+import com.example.SucceSS.web.dto.TokenDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpStatus.OK;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "카카오 로그인")
+    @ResponseStatus(OK)
+    @GetMapping("/sign-in/kakao")
+    public ResponseEntity<ApiResponse<TokenDto>> signInKakao(@RequestParam("code") String code) throws IOException {
+        return ResponseEntity.status(OK).body(ApiResponse.onSuccess(authService.signIn(code)));
+    }
+
+    @Operation(summary = "테스트")
+    @GetMapping("/sign-in/test")
+    public ResponseEntity<ApiResponse<String>> test(@RequestParam("code") String code) throws IOException {
+        return ResponseEntity.status(OK).body(ApiResponse.onSuccess(code));
+    }
+
+    @Operation(summary = "토큰 테스트")
+    @GetMapping("/token-test")
+    public ResponseEntity<ApiResponse<String>> testToken(@RequestParam("code") String code) {
+        return ResponseEntity.status(OK).body(ApiResponse.onSuccess(code));
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/web/controller/KakaoLoginController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/KakaoLoginController.java
@@ -1,4 +1,0 @@
-package com.example.SucceSS.web.controller;
-
-public class KakaoLoginController {
-}

--- a/src/main/java/com/example/SucceSS/web/controller/KakaoLogoutController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/KakaoLogoutController.java
@@ -1,4 +1,0 @@
-package com.example.SucceSS.web.controller;
-
-public class KakaoLogoutController {
-}

--- a/src/main/java/com/example/SucceSS/web/dto/KakaoAccountDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/KakaoAccountDto.java
@@ -1,4 +1,54 @@
 package com.example.SucceSS.web.dto;
 
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.domain.common.Role;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoAccountDto {
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+        //프로필 : 닉네임
+        @JsonProperty("profile")
+        public Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+        }
+
+    }
+
+    public static Member toMemberEntity(KakaoAccountDto dto) {
+        return Member.builder()
+                .socialId(dto.getId().toString())
+                .nickname(dto.getKakaoAccount().getProfile().getNickName())
+                .userRole(Role.ROLE_USER)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/SucceSS/web/dto/KakaoTokenDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/KakaoTokenDto.java
@@ -1,4 +1,24 @@
 package com.example.SucceSS.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoTokenDto {
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    @JsonProperty("scope")
+    public String scope;
 }

--- a/src/main/java/com/example/SucceSS/web/dto/MemberRequestDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/MemberRequestDto.java
@@ -1,4 +1,0 @@
-package com.example.SucceSS.web.dto;
-
-public class MemberRequestDto {
-}

--- a/src/main/java/com/example/SucceSS/web/dto/SignUpRequestDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/SignUpRequestDto.java
@@ -1,7 +1,11 @@
 package com.example.SucceSS.web.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
-public class LoginResponseDto {
+public class SignUpRequestDto {
+
+
 }

--- a/src/main/java/com/example/SucceSS/web/dto/TokenDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/TokenDto.java
@@ -1,0 +1,12 @@
+package com.example.SucceSS.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
+# Database
 spring.application.name=SucceSS
+spring.datasource.url=jdbc:mysql://localhost:3308/SucceSS
+spring.datasource.username=root
+spring.datasource.password=ROOTjieun123@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Hibernate configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+


### PR DESCRIPTION
### 구현 내용
- 리프레시토큰은 아직 안 만들었고, 일단 로그인 후 액세스 토큰 발급받아서 api 요청에 지장 없도록 하는데까지 구현했습니다
- 로그인에 필요한 MemberEntity, Repository만 생성한 상태입니다
- 로그인에 필요한 Spring Security 설정을 진행했습니다
- ApiResponse 및 ErrorStatus를 작성했습니다

---

### 확인할 부분

- springboot 버전 3.4.x -> 3.3.6으로 다운그레이드 했습니다 Swagger랑 충돌이 나더라구요
- http://localhost:8080/swagger-ui/index.html#/ : 스웨거 접속
- ApiResponse랑 ErrorStatus는 유진님이 보내주셨던 리포지토리 기반으로 작성해봤습니다. 근데 조금씩 바꾸다보니 중구난방이 된 것 같아서 이대로 사용해도 될 지 확인 부탁드려요. 편하게 변경해주셔도 됩니다!
- properties는 직접 변경해서 사용해주세요

---


resolved #1 