### PR TITLE
[Feat/#2/chat config] Kafka, STOMP, MongoDB 관련 환경설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,15 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// MongoDB
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConfig.java
@@ -1,0 +1,25 @@
+package com.example.SucceSS.config.chat.Kafka;
+
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class KafkaConfig {
+
+    // 토픽 이름 설정
+    private final String request = "/topic/user-request";
+    private final String response = "/topic/ai-response";
+
+    // 토픽 두 개 생성
+    @Bean
+    public List<NewTopic> createTopic() {
+        return List.of(
+            new NewTopic(request, 100, (short) 1),
+            new NewTopic(response, 100, (short) 1)
+        );
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumerConfig.java
@@ -1,0 +1,68 @@
+package com.example.SucceSS.config.chat.Kafka;
+
+import com.example.SucceSS.web.dto.ChatDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private Map<String, Object> consumerConfigurations(String groupId) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        configs.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        return configs;
+    }
+    // Consumer 생성 - user request Consumer
+    @Bean
+    public ConsumerFactory<String, ChatDto> userRequestConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(
+                consumerConfigurations("user-request-group"),
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(ChatDto.class))
+        );
+    }
+    // Kafka 리스너 만들고 관리 - user request Consumer
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChatDto> userRequestKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatDto> kafkaListenerContainerFactory = new ConcurrentKafkaListenerContainerFactory<>();
+        kafkaListenerContainerFactory.setConsumerFactory(userRequestConsumerFactory());
+        return kafkaListenerContainerFactory;
+    }
+    // Consumer 생성 - ai response Consumer
+    @Bean
+    public ConsumerFactory<String, ChatDto> aiResponseConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(
+                consumerConfigurations("ai-response-group"),
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(ChatDto.class))
+        );
+    }
+    // Kafka 리스너 만들고 관리 - ai response Consumer
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChatDto> aiResponseKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatDto> kafkaListenerContainerFactory = new ConcurrentKafkaListenerContainerFactory<>();
+        kafkaListenerContainerFactory.setConsumerFactory(aiResponseConsumerFactory());
+        return kafkaListenerContainerFactory;
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducerConfig.java
@@ -1,0 +1,38 @@
+package com.example.SucceSS.config.chat.Kafka;
+
+import com.example.SucceSS.web.dto.ChatDto;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+    // 브로커 주소
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, ChatDto> producerFactory() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configs);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ChatDto> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
@@ -1,0 +1,19 @@
+package com.example.SucceSS.config.chat;
+
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/chat-user-request");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
@@ -1,0 +1,5 @@
+package com.example.SucceSS.web.dto;
+
+public class ChatDto {
+    // roomId 필요
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,3 @@
 # spring security
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG
-
-# Kafka broker
-spring.kafka.bootstrap-servers=localhost:9092,kafka-broker1.company.com:9092,kafka-cluster1.us-west-2.amazonaws.com:9092

--- a/src/main/resources/static/chat.js
+++ b/src/main/resources/static/chat.js
@@ -1,0 +1,43 @@
+// SockJS와 STOMP 라이브러리 필요 - npm install @stomp/stompjs sockjs-client
+import Stomp from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+const socket = new SockJS('/ws-chat');
+const stompClient = Stomp.over(socket);
+let roomId = 0;
+
+stompClient.onConnect = onConnect;
+stompClient.onWebSocketError = function (error) {
+    console.error('WebSocket 에러 : ' + error);
+}
+stompClient.onStompError = function (frame) {npmnpm
+    console.error('오류 보고 : ' + frame.headers['message']);
+    console.error('세부 정보 : ' + frame.body);
+}
+
+// STOMP 연결 성공
+function onConnect() {
+        console.log('WebSocket 연결 성공 : ' + frame);
+        setConnectedStatus(); // 코드 작성 필요
+        stompClient.subscribe(`/topic/user-request`, () => {});
+        stompClient.subscribe('/topic/ai-response', () => {});
+}
+
+// 연결되었을 때 UI 변경
+function setConnectedStatus() {
+}
+
+// 연결 및 해제
+function connect() {
+    stompClient.connect();
+}
+function disconnect() {
+    stompClient.disconnect();
+}
+
+// 이벤트 발생
+$(function() {
+    // 채팅방 생성 OR 기존 채팅방 누를 경우 connect() 호출
+    // 채팅방 나갈 경우 disconnect() 호출
+    // 메시지 보낼 경우 sendMessage() 호출
+});


### PR DESCRIPTION
<<구현내용>>
- EC2에 Kafka, Zookeeper, MongoDB 실행환경 구성
- KafkaConsumerConfig, KafkaProducerConfig, KafkaConfig 작성
- WebSocketConfig 작성
- chat.js 초안 작성

<<설명>>
이런저런 방식을 생각해보다가 일단 이런 식으로 공동의 토픽 2개와 토픽 내의 여러 개의 파티션을 공유하고, Consumer Group이 파티션을 분배해서 처리하는 방식으로 동작하는 걸로 생각하고 설정해놨습니다! 이후 채팅 코드 구현 시 메시지에 포함되어있는 채팅방번호를 기준으로 해당 채팅방에 메시지를 보내는 방식으로 구현하면 될 것 같습니다. 혹시 더 좋은 방식이 있다면 변경하셔도 됩니다 😄 

<img width="700" alt="작동방식" src="https://github.com/user-attachments/assets/14f9f1f3-77b8-4c2c-9de4-501b8c1ebf8c" />
