### PR TITLE
Feat/#7 chat room : 채팅방 생성 및 설정 변경

### DIFF
--- a/.github/workflows/dev-gradle.yml
+++ b/.github/workflows/dev-gradle.yml
@@ -59,14 +59,37 @@ jobs:
         key: ${{ secrets.EC2_KEY }}
 
         script: |
-          sudo docker kill ${{ secrets.PROJECT_NAME }}
-          sudo docker rm -f ${{ secrets.PROJECT_NAME }}
-          sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
+          # 1️. 기존 컨테이너 확인 및 삭제
+          EXISTING_CONTAINER_ID=$(docker ps -aq -f name=${{ secrets.PROJECT_NAME }})
+          if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
+            echo "Stopping and removing existing container..."
+            sudo docker stop $EXISTING_CONTAINER_ID || true
+            sudo docker rm -f $EXISTING_CONTAINER_ID || true
+          fi
 
+          # 2️. 혹시라도 남아 있는 컨테이너 ID가 있으면 다시 삭제
+          EXISTING_CONTAINER_ID=$(docker ps -aq -f name=${{ secrets.PROJECT_NAME }})
+          if [ ! -z "$EXISTING_CONTAINER_ID" ]; then
+            echo "Force removing existing container..."
+            sudo docker rm -f $EXISTING_CONTAINER_ID || true
+          fi
+
+          # 3️. 기존 이미지 강제 삭제
+          IMAGE_ID=$(docker images -q ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:latest)
+          if [ ! -z "$IMAGE_ID" ]; then
+            echo "Removing existing image..."
+            sudo docker rmi -f $IMAGE_ID || true
+          fi
+
+          # 4️. 최신 이미지 가져오기
+          sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:latest
+
+          # 5️. 새 컨테이너 실행
           sudo docker run -p ${{ secrets.PORT }}:${{ secrets.PORT }} \
           --name ${{ secrets.PROJECT_NAME }} \
           -e SPRING_DATASOURCE_URL=${{ secrets.DB_URL }} \
           -e SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }} \
           -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }} \
-          -d ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
+          -e SPRING_KAFKA_BOOTSTRAP_SERVERS="${{ secrets.SPRING_KAFKA_BOOTSTRAP_SERVERS }}" \
+          -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
+          -d ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.properties
+**/resources/application.properties
+**/resources/*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,19 @@ services:
     volumes:
       - ./databases/config:/etc/mysql/conf.d
     ports:
-      - "3306:3306"
+      - "3307:3306"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - '2181:2181'
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/dockerd.sock:/var/run/docker.sock

--- a/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
@@ -24,6 +24,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
+    public static ApiResponse<Void> onSuccess() {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), null);
+    }
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
         return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
@@ -11,22 +11,22 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaConsumer {
-    private final String USER_TOPIC = "/topic/user-request";
-    private final String AI_TOPIC = "/topic/ai-response";
-    private final String USER_GROUP = "/topic/ai-response";
-    private final String AI_GROUP = "/topic/ai-response";
+    private final String USER_TOPIC = "user-request";
+    private final String AI_TOPIC = "ai-response";
+    private final String USER_GROUP = "ai-response";
+    private final String AI_GROUP = "ai-response";
     private final SimpMessagingTemplate template;
 
-    @KafkaListener(groupId = USER_GROUP ,topics=USER_TOPIC)
+    @KafkaListener(groupId = USER_GROUP ,topics=USER_TOPIC , containerFactory = "aiResponseKafkaListenerContainerFactory")
     public void listenUserChat(ChatDto chatDto){
         // DB 저장
         // 모델로 send
     }
 
-    @KafkaListener(groupId = AI_GROUP ,topics=AI_TOPIC)
+    @KafkaListener(groupId = AI_GROUP ,topics=AI_TOPIC, containerFactory = "userRequestKafkaListenerContainerFactory")
     public void listenAiChat(ChatDto chatDto){
         try {
-            template.convertAndSend("/chatRoom/"+chatDto.getChatRoomId(), chatDto);
+            template.convertAndSend("/topic/chatRoom/"+chatDto.getChatRoomId(), chatDto);
             log.info("sent message: {}", chatDto.getContent());
         } catch (Exception e) {
             log.error("Error sending message to WebSocket", e);

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
@@ -21,6 +21,14 @@ public class KafkaConsumer {
     public void listenUserChat(ChatDto chatDto){
         // DB 저장
         // 모델로 send
+        try {
+            /*
+            template.convertAndSend("/topic/chatRoom/"+chatDto.getChatRoomId(), chatDto);
+            log.info("sent message: {}", chatDto.getContent());
+             */
+        } catch (Exception e) {
+            log.error("Error sending message to WebSocket", e);
+        }
     }
 
     @KafkaListener(groupId = AI_GROUP ,topics=AI_TOPIC, containerFactory = "userRequestKafkaListenerContainerFactory")

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
@@ -1,0 +1,35 @@
+package com.example.SucceSS.config.chat.Kafka;
+
+import com.example.SucceSS.web.dto.ChatDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaConsumer {
+    private final String USER_TOPIC = "/topic/user-request";
+    private final String AI_TOPIC = "/topic/ai-response";
+    private final String USER_GROUP = "/topic/ai-response";
+    private final String AI_GROUP = "/topic/ai-response";
+    private final SimpMessagingTemplate template;
+
+    @KafkaListener(groupId = USER_GROUP ,topics=USER_TOPIC)
+    public void listenUserChat(ChatDto chatDto){
+        // DB 저장
+        // 모델로 send
+    }
+
+    @KafkaListener(groupId = AI_GROUP ,topics=AI_TOPIC)
+    public void listenAiChat(ChatDto chatDto){
+        try {
+            template.convertAndSend("/chatRoom/"+chatDto.getChatRoomId(), chatDto);
+            log.info("sent message: {}", chatDto.getContent());
+        } catch (Exception e) {
+            log.error("Error sending message to WebSocket", e);
+        }
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
@@ -17,9 +17,8 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class KafkaProducer {
     private final KafkaTemplate<String, ChatDto> kafkaTemplate;
-    private final String USER_TOPIC = "/topic/user-request";
-    private final String AI_TOPIC = "/topic/ai-response";
-    private final ChatRoomService chatRoomService;
+    private final String USER_TOPIC = "user-request";
+    private final String AI_TOPIC = "ai-response";
 
     public void sendMessageToUser(ChatDto dto) {
         CompletableFuture<SendResult<String, ChatDto>> completableFuture =

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
@@ -1,0 +1,42 @@
+package com.example.SucceSS.config.chat.Kafka;
+
+import com.example.SucceSS.service.ChatService.ChatRoomService;
+import com.example.SucceSS.web.dto.ChatDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducer {
+    private final KafkaTemplate<String, ChatDto> kafkaTemplate;
+    private final String USER_TOPIC = "/topic/user-request";
+    private final String AI_TOPIC = "/topic/ai-response";
+    private final ChatRoomService chatRoomService;
+
+    public void sendMessageToUser(ChatDto dto) {
+        CompletableFuture<SendResult<String, ChatDto>> completableFuture =
+                kafkaTemplate.send(AI_TOPIC, dto).toCompletableFuture();
+
+        completableFuture
+                .thenAccept(result -> log.info("Successfully sent message: {}", dto.getContent()))
+                .exceptionally(ex -> {
+                    log.error("Failed to send message: {}", dto.getContent(), ex);
+                    return null;
+                });
+        log.info("Produce message: {}", dto.getContent());
+    }
+
+    public void sendMessageToAI() {
+        // jwt 검증 로직 필요
+    }
+
+
+}

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaProducer.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.ListenableFutureCallback;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -33,8 +31,19 @@ public class KafkaProducer {
         log.info("Produce message: {}", dto.getContent());
     }
 
-    public void sendMessageToAI() {
+    public void sendMessageToAI(ChatDto dto) {
         // jwt 검증 로직 필요
+
+        CompletableFuture<SendResult<String, ChatDto>> completableFuture =
+                kafkaTemplate.send(USER_TOPIC, dto).toCompletableFuture();
+
+        completableFuture
+                .thenAccept(result -> log.info("Successfully sent message: {}", dto.getContent()))
+                .exceptionally(ex -> {
+                    log.error("Failed to send message: {}", dto.getContent(), ex);
+                    return null;
+                });
+        log.info("Produce message: {}", dto.getContent());
     }
 
 

--- a/src/main/java/com/example/SucceSS/config/chat/MongoDBConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/MongoDBConfig.java
@@ -1,0 +1,21 @@
+package com.example.SucceSS.config.chat;
+
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration
+public class MongoDBConfig {
+    @Value("${data.mongodb.uri}")
+    private String mongoClientUri;
+
+    @Value("${mongodb.database}")
+    private String dbName;
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(MongoClients.create(mongoClientUri), dbName);
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/MongoDBConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/MongoDBConfig.java
@@ -5,13 +5,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
+@EnableMongoRepositories(basePackages = "com.example.SucceSS.repository")
 public class MongoDBConfig {
-    @Value("${data.mongodb.uri}")
+    @Value("${spring.data.mongodb.uri}")
     private String mongoClientUri;
 
-    @Value("${mongodb.database}")
+    @Value("${spring.data.mongodb.database}")
     private String dbName;
 
     @Bean

--- a/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
@@ -1,19 +1,25 @@
 package com.example.SucceSS.config.chat;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@EnableWebSocketMessageBroker
+@Configuration
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
-        registry.setApplicationDestinationPrefixes("/chat-user-request");
+
+        // @MessageMapping("/chat/message") -> send message to /pub/chat/message
+        registry.setApplicationDestinationPrefixes("/pub");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*");
     }
 }

--- a/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/SucceSS/config/security/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
             "/api/auth/sign-up/**",
             "/api/auth/sign-in/**",
             "/error",
-            "/api/auth/reissue"
+            "/api/auth/reissue",
+            "/ws-chat/**"
     };
     private static final String[] SWAGGER_WHITELIST = {
             "/swagger-ui/**", "/v3/api-docs/**"

--- a/src/main/java/com/example/SucceSS/converter/MemberConverter.java
+++ b/src/main/java/com/example/SucceSS/converter/MemberConverter.java
@@ -1,4 +1,0 @@
-package com.example.SucceSS.converter;
-
-public class MemberConverter {
-}

--- a/src/main/java/com/example/SucceSS/domain/Chat.java
+++ b/src/main/java/com/example/SucceSS/domain/Chat.java
@@ -1,0 +1,37 @@
+package com.example.SucceSS.domain;
+
+import com.example.SucceSS.web.dto.ChatDto;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document(collection = "chatting")
+public class Chat {
+    @Id
+    private String id;
+    private Long chatRoomId;
+    private Long memberId;
+    private String content;
+    private LocalDateTime sendDate;
+    private String type;
+
+    public static Chat of(ChatDto dto) {
+        return Chat.builder()
+                .chatRoomId(dto.getChatRoomId())
+                .type(dto.getType())
+                .content(dto.getContent())
+                .memberId(dto.getMemberId())
+                .sendDate(dto.getSendDate())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/domain/ChatRoom.java
+++ b/src/main/java/com/example/SucceSS/domain/ChatRoom.java
@@ -1,0 +1,35 @@
+package com.example.SucceSS.domain;
+
+import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_id", nullable = false)
+    private Long chatRoomId;
+
+    @Column(name="member_id")
+    private Long memberId;
+
+    private String title;
+
+    public ChatRoomResponseDto toResponse() {
+        return ChatRoomResponseDto.builder()
+                .chatRoomId(this.chatRoomId)
+                .memberId(this.memberId)
+                .title(this.title)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/repository/ChatRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRepository.java
@@ -1,0 +1,7 @@
+package com.example.SucceSS.repository;
+
+import com.example.SucceSS.domain.Chat;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatRepository extends MongoRepository<Chat, String> {
+}

--- a/src/main/java/com/example/SucceSS/repository/ChatRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRepository.java
@@ -2,6 +2,8 @@ package com.example.SucceSS.repository;
 
 import com.example.SucceSS.domain.Chat;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatRepository extends MongoRepository<Chat, String> {
 }

--- a/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.example.SucceSS.repository;
+
+import com.example.SucceSS.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
+
+}

--- a/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
@@ -2,7 +2,9 @@ package com.example.SucceSS.repository;
 
 import com.example.SucceSS.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
 
 }

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
@@ -1,0 +1,46 @@
+package com.example.SucceSS.service.ChatService;
+
+import com.example.SucceSS.config.chat.Kafka.KafkaProducer;
+import com.example.SucceSS.domain.Chat;
+import com.example.SucceSS.domain.ChatRoom;
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.repository.ChatRepository;
+import com.example.SucceSS.repository.ChatRoomRepository;
+import com.example.SucceSS.repository.MemberRepository;
+import com.example.SucceSS.web.dto.ChatDto;
+import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRepository chatRepository;
+    private final KafkaProducer producer;
+
+    @Transactional
+    public ChatRoomResponseDto createChatRoom(Member member) {
+        ChatRoom chatRoom = ChatRoom.builder()
+                .memberId(member.getId())
+                .title("New Chat")
+                .build();
+
+        chatRoomRepository.save(chatRoom);
+
+        sendFirstMessage(chatRoom);
+        return chatRoom.toResponse();
+    }
+
+    private void sendFirstMessage(ChatRoom chatRoom) {
+        ChatDto dto = ChatDto.toChatDto(chatRoom.getChatRoomId(),chatRoom.getMemberId(), "New Chat", "CHAT");
+        producer.sendMessageToUser(dto);
+
+        chatRepository.save(Chat.of(dto));
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatService.java
@@ -1,0 +1,26 @@
+package com.example.SucceSS.service.ChatService;
+
+import com.example.SucceSS.config.chat.Kafka.KafkaProducer;
+import com.example.SucceSS.domain.Chat;
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.repository.ChatRepository;
+import com.example.SucceSS.web.dto.ChatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final KafkaProducer producer;
+    private final ChatRepository chatRepository;
+
+    @Transactional
+    public void userSendChat(ChatDto chatDto, Member member) {
+        chatRepository.save(Chat.of(chatDto));
+
+        producer.sendMessageToAI(chatDto);
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/SucceSS/service/MemberService/MemberService.java
@@ -1,7 +1,13 @@
 package com.example.SucceSS.service.MemberService;
 
+import com.example.SucceSS.repository.MemberRepository;
+import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
+    private final MemberRepository memberRepository;
+
 }

--- a/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
+++ b/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
@@ -20,4 +20,9 @@ public class GetCurrentUser {
                 .orElseThrow(MemberNotFound::new);
     }
 
+    public Member getCurrentUserByAuth(Authentication auth) {
+        return memberRepository.findBySocialId(auth.getName())
+                .orElseThrow(MemberNotFound::new);
+    }
+
 }

--- a/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
+++ b/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
@@ -1,0 +1,23 @@
+package com.example.SucceSS.utils;
+
+import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.domain.Member;
+import com.example.SucceSS.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class GetCurrentUser {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return memberRepository.findBySocialId(authentication.getName())
+                .orElseThrow(MemberNotFound::new);
+    }
+
+}

--- a/src/main/java/com/example/SucceSS/utils/MemberConverter.java
+++ b/src/main/java/com/example/SucceSS/utils/MemberConverter.java
@@ -1,0 +1,4 @@
+package com.example.SucceSS.utils;
+
+public class MemberConverter {
+}

--- a/src/main/java/com/example/SucceSS/web/controller/AuthController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.SucceSS.web.controller;
 import com.example.SucceSS.apiPayload.ApiResponse;
 import com.example.SucceSS.apiPayload.exception.MemberNotFound;
 import com.example.SucceSS.service.MemberService.AuthService;
+import com.example.SucceSS.web.dto.LoginResponseDto;
 import com.example.SucceSS.web.dto.TokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,7 @@ public class AuthController {
     @Operation(summary = "카카오 로그인")
     @ResponseStatus(OK)
     @GetMapping("/sign-in/kakao")
-    public ResponseEntity<ApiResponse<TokenDto>> signInKakao(@RequestParam("code") String code) throws IOException {
+    public ResponseEntity<ApiResponse<LoginResponseDto>> signInKakao(@RequestParam("code") String code) throws IOException {
         return ResponseEntity.status(OK).body(ApiResponse.onSuccess(authService.signIn(code)));
     }
 

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -39,7 +39,8 @@ public class ChatController {
     // pub/chat/message 경로로 메세지 전송 : setApplicationDestinationPrefixes
     @MessageMapping("/chat/message")
     @Operation(summary = "웹소켓 메세지 전송")
-    public void sendSocketMessage(@Valid @RequestBody ChatDto chatDto){
-        //return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.userSendChat(getCurrentUser.getCurrentUser())));
+    public ResponseEntity<ApiResponse<Void>> sendSocketMessage(@Valid @RequestBody ChatDto chatDto, Authentication auth){
+        chatService.userSendChat(chatDto, getCurrentUser.getCurrentUserByAuth(auth));
+        return ResponseEntity.ok(ApiResponse.onSuccess());
     }
 }

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -2,12 +2,19 @@ package com.example.SucceSS.web.controller;
 
 import com.example.SucceSS.apiPayload.ApiResponse;
 import com.example.SucceSS.service.ChatService.ChatRoomService;
+import com.example.SucceSS.service.ChatService.ChatService;
 import com.example.SucceSS.service.MemberService.MemberService;
 import com.example.SucceSS.utils.GetCurrentUser;
+import com.example.SucceSS.web.dto.ChatDto;
 import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,9 +27,19 @@ public class ChatController {
     private final GetCurrentUser getCurrentUser;
     private final ChatRoomService chatRoomService;
 
+    private final ChatService chatService;
+
 
     @PostMapping(value = "/room")
+    @Operation(summary = "채팅방 생성")
     public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom() {
         return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.createChatRoom(getCurrentUser.getCurrentUser())));
+    }
+
+    // pub/chat/message 경로로 메세지 전송 : setApplicationDestinationPrefixes
+    @MessageMapping("/chat/message")
+    @Operation(summary = "웹소켓 메세지 전송")
+    public void sendSocketMessage(@Valid @RequestBody ChatDto chatDto){
+        //return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.userSendChat(getCurrentUser.getCurrentUser())));
     }
 }

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -1,0 +1,28 @@
+package com.example.SucceSS.web.controller;
+
+import com.example.SucceSS.apiPayload.ApiResponse;
+import com.example.SucceSS.service.ChatService.ChatRoomService;
+import com.example.SucceSS.service.MemberService.MemberService;
+import com.example.SucceSS.utils.GetCurrentUser;
+import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/chat")
+public class ChatController {
+    private final MemberService memberService;
+    private final GetCurrentUser getCurrentUser;
+    private final ChatRoomService chatRoomService;
+
+
+    @PostMapping(value = "/room")
+    public ResponseEntity<ApiResponse<ChatRoomResponseDto>> createChatRoom() {
+        return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.createChatRoom(getCurrentUser.getCurrentUser())));
+    }
+}

--- a/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
@@ -1,5 +1,30 @@
 package com.example.SucceSS.web.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
 public class ChatDto {
-    // roomId 필요
+    private Long chatRoomId;
+    private Long memberId;
+    private LocalDateTime sendDate;
+    private String content;
+    private String type;
+
+    public static ChatDto toChatDto(Long chatRoomId, Long memberId, String content, String type) {
+        return ChatDto.builder()
+                .chatRoomId(chatRoomId)
+                .memberId(memberId)
+                .content(content)
+                .sendDate(LocalDateTime.now())
+                .type(type)
+                .build();
+    }
 }

--- a/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
@@ -1,19 +1,22 @@
 package com.example.SucceSS.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
-public class ChatDto {
+public class ChatDto implements Serializable {
     private Long chatRoomId;
     private Long memberId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime sendDate;
     private String content;
     private String type;

--- a/src/main/java/com/example/SucceSS/web/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatRoomResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.SucceSS.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ChatRoomResponseDto {
+    private Long chatRoomId;
+    private Long memberId;
+    private String title;
+}

--- a/src/main/java/com/example/SucceSS/web/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/LoginResponseDto.java
@@ -1,7 +1,26 @@
 package com.example.SucceSS.web.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
+@Getter
+@AllArgsConstructor
 public class LoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private boolean firstLogIn;
+
+    public LoginResponseDto(boolean firstLogIn) {
+        this.firstLogIn = firstLogIn;
+    }
+
+    public void setTokens(TokenDto dto) {
+        this.accessToken = dto.getAccessToken();
+        this.refreshToken = dto.getRefreshToken();
+        this.grantType = dto.getGrantType();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=SucceSS

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+# Database
+spring.application.name=SucceSS
+spring.datasource.url=jdbc:mysql://success.c9o2muimyf8j.ap-northeast-2.rds.amazonaws.com:3306/success
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Hibernate configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# kakao social login
+kakao.redirect.uri=http://localhost:3000/oauth
+kakao.client.id=${KAKAO_CLIENT_ID}
+
+# spring security
+jwt.secret=${JWT_SECRET}
+logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
- Kafka Consumer, Producer 
- 채팅방 생성 api
- MongoDBConfig
- 관련 엔티티 : Chat(MongoDB 용, 채팅메세지 데이터), ChatRoom(MySQL용, 채팅방 데이터) 엔티티와 Repository 생성
- authentication 통해서 현재 로그인 한 멤버 가져오는 GetCurrentMember 추가했습니다. 활용해주세요~
- topic 변경 : 기존 uri 형태 → ai-response, user-request로 변경
  - 확정된 건 아니니까 자유롭게 변경해주셔도 됩니다!