### PR TITLE
Feat/#7 채팅방 생성, 삭제, 채팅내역 조회

### DIFF
--- a/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/SucceSS/apiPayload/ApiResponse.java
@@ -27,6 +27,9 @@ public class ApiResponse<T> {
     public static ApiResponse<Void> onSuccess() {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), null);
     }
+    public static ApiResponse<Void> onSuccessWithMessage(String message) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , message, null);
+    }
 
     public static <T> ApiResponse<T> of(BaseCode code, T result){
         return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);

--- a/src/main/java/com/example/SucceSS/repository/ChatRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRepository.java
@@ -1,10 +1,13 @@
 package com.example.SucceSS.repository;
 
 import com.example.SucceSS.domain.Chat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends MongoRepository<Chat, String> {
     void deleteByChatRoomId(Long chatRoomId);
+    Page<Chat> findByChatRoomId(Long chatRoomId, Pageable pageable);
 }

--- a/src/main/java/com/example/SucceSS/repository/ChatRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends MongoRepository<Chat, String> {
+    void deleteByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
@@ -36,6 +36,13 @@ public class ChatRoomService {
         return chatRoom.toResponse();
     }
 
+    @Transactional
+    // MongoDB 트랜잭션 설정 필요
+    public void deleteChatRoom(Long chatRoomId) {
+        chatRepository.deleteByChatRoomId(chatRoomId);
+        chatRoomRepository.deleteById(chatRoomId);
+    }
+
     private void sendFirstMessage(ChatRoom chatRoom) {
         ChatDto dto = ChatDto.toChatDto(chatRoom.getChatRoomId(),chatRoom.getMemberId(), "New Chat", "CHAT");
         producer.sendMessageToUser(dto);

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
@@ -11,6 +11,8 @@ import com.example.SucceSS.web.dto.ChatDto;
 import com.example.SucceSS.web.dto.ChatRoomResponseDto;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,11 @@ public class ChatRoomService {
     public void deleteChatRoom(Long chatRoomId) {
         chatRepository.deleteByChatRoomId(chatRoomId);
         chatRoomRepository.deleteById(chatRoomId);
+    }
+
+    public Page<ChatDto> getChatPages(Long chatRoomId, Pageable pageable) {
+        return chatRepository.findByChatRoomId(chatRoomId, pageable)
+                .map(ChatDto::from);
     }
 
     private void sendFirstMessage(ChatRoom chatRoom) {

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -10,6 +10,8 @@ import com.example.SucceSS.web.dto.ChatRoomResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.Authentication;
@@ -38,6 +40,13 @@ public class ChatController {
     public ResponseEntity<ApiResponse<Void>> deleteChatRoom(@PathVariable Long chatRoomId) {
         chatRoomService.deleteChatRoom( chatRoomId);
         return ResponseEntity.ok(ApiResponse.onSuccessWithMessage("채팅방 삭제 성공 : "+chatRoomId));
+    }
+
+    @GetMapping(value="/room/{chatRoomId}")
+    @Operation(summary = "채팅방 내역 불러오기")
+    public ResponseEntity<ApiResponse<Page<ChatDto>>> getChatPages(@PathVariable Long chatRoomId, Pageable pageable) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(chatRoomService.getChatPages(chatRoomId, pageable)));
     }
 
     // pub/chat/message 경로로 메세지 전송 : setApplicationDestinationPrefixes

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -13,10 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -36,8 +33,15 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.onSuccess(chatRoomService.createChatRoom(getCurrentUser.getCurrentUser())));
     }
 
+    @DeleteMapping(value="/room/{chatRoomId}")
+    @Operation(summary = "채팅방 삭제")
+    public ResponseEntity<ApiResponse<Void>> deleteChatRoom(@PathVariable Long chatRoomId) {
+        chatRoomService.deleteChatRoom( chatRoomId);
+        return ResponseEntity.ok(ApiResponse.onSuccessWithMessage("채팅방 삭제 성공 : "+chatRoomId));
+    }
+
     // pub/chat/message 경로로 메세지 전송 : setApplicationDestinationPrefixes
-    @MessageMapping("/chat/message")
+    @MessageMapping(value = "/chat/message")
     @Operation(summary = "웹소켓 메세지 전송")
     public ResponseEntity<ApiResponse<Void>> sendSocketMessage(@Valid @RequestBody ChatDto chatDto, Authentication auth){
         chatService.userSendChat(chatDto, getCurrentUser.getCurrentUserByAuth(auth));

--- a/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatDto.java
@@ -1,5 +1,6 @@
 package com.example.SucceSS.web.dto;
 
+import com.example.SucceSS.domain.Chat;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +29,16 @@ public class ChatDto implements Serializable {
                 .content(content)
                 .sendDate(LocalDateTime.now())
                 .type(type)
+                .build();
+    }
+
+    public static ChatDto from(Chat chat) {
+        return ChatDto.builder()
+                .chatRoomId(chat.getChatRoomId())
+                .memberId(chat.getMemberId())
+                .sendDate(chat.getSendDate())
+                .content(chat.getContent())
+                .type(chat.getType())
                 .build();
     }
 }


### PR DESCRIPTION
- 채팅방 생성, 삭제, 내역조회 api 추가했습니다
- 추후에 수정 필요한 부분
  - MongoDB에 Transactional 적용하고 더 나아가서 JPA랑 같은 트랜잭션으로 묶을 수도 있다는게 그런 처리들은 안 한 상태입니다
  - 최소 @Transactional 적용되도록은 추후에 수정이 필요할 것 같습니다

Issue
resolved #7 