### PR TITLE
Feat/#7 chat room 채팅방 조회, 채팅 전송 테스트, StompHandler, StompErrorHandler 추가

### DIFF
--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConfig.java
@@ -5,11 +5,13 @@ import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 
 import java.util.List;
 import java.util.Properties;
 
 @Configuration
+@EnableKafka
 public class KafkaConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")

--- a/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
+++ b/src/main/java/com/example/SucceSS/config/chat/Kafka/KafkaConsumer.java
@@ -22,10 +22,9 @@ public class KafkaConsumer {
         // DB 저장
         // 모델로 send
         try {
-            /*
+
             template.convertAndSend("/topic/chatRoom/"+chatDto.getChatRoomId(), chatDto);
             log.info("sent message: {}", chatDto.getContent());
-             */
         } catch (Exception e) {
             log.error("Error sending message to WebSocket", e);
         }

--- a/src/main/java/com/example/SucceSS/config/chat/StompErrorHandler.java
+++ b/src/main/java/com/example/SucceSS/config/chat/StompErrorHandler.java
@@ -1,0 +1,60 @@
+package com.example.SucceSS.config.chat;
+
+import com.example.SucceSS.apiPayload.ApiResponse;
+import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
+import com.example.SucceSS.apiPayload.exception.NoBearerException;
+import com.example.SucceSS.apiPayload.status.ErrorStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@ControllerAdvice
+@Slf4j
+@RequiredArgsConstructor
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+    private final ObjectMapper objectMapper;
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        if (ex instanceof MessageDeliveryException) {
+            Throwable cause = ex.getCause();
+            log.error("Error occurred ", cause);
+            if (cause instanceof ExpiredJwtException) {
+                return sendErrorMessage(ApiResponse.onFailure(ErrorStatus._EXPIRED_TOKEN.getCode(), ErrorStatus._EXPIRED_TOKEN.getMessage()), ex);
+            } else if (cause instanceof MalformedJwtException) {
+                return sendErrorMessage(ApiResponse.onFailure(ErrorStatus._MALFORMED.getCode(), ErrorStatus._MALFORMED.getMessage()), ex);
+            } else {
+                return sendErrorMessage(ApiResponse.onFailure(ErrorStatus._INTERNAL_SERVER_ERROR.getCode(), ErrorStatus._INTERNAL_SERVER_ERROR.getMessage()), ex);
+            }
+        }
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+    private Message<byte[]> sendErrorMessage(ApiResponse<Void> response, Throwable e) {
+        log.error("Failed to convert ErrorResponse to JSON", e);
+        StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.ERROR);
+        headers.setMessage(response.getMessage());
+        headers.setLeaveMutable(true);
+
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            return MessageBuilder.createMessage(json.getBytes(StandardCharsets.UTF_8),
+                    headers.getMessageHeaders());
+        } catch (JsonProcessingException ex) {
+            log.error("Failed to convert ErrorResponse to JSON", ex);
+            return MessageBuilder.createMessage(response.getMessage().getBytes(StandardCharsets.UTF_8),
+                    headers.getMessageHeaders());
+        }
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/StompHandler.java
+++ b/src/main/java/com/example/SucceSS/config/chat/StompHandler.java
@@ -1,0 +1,47 @@
+package com.example.SucceSS.config.chat;
+
+import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
+import com.example.SucceSS.apiPayload.exception.NoBearerException;
+import com.example.SucceSS.config.security.JwtProvider;
+import com.example.SucceSS.utils.JwtUtils;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final JwtUtils jwtUtils;
+
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            try {
+                String token = jwtUtils.extractToken(accessor.getFirstNativeHeader("Authorization"));
+                if (jwtProvider.validateToken(token)) {
+                    Authentication auth = jwtProvider.getAuthentication(token);
+                    accessor.getSessionAttributes().put("auth", auth);
+                }
+            } catch (Exception e) {
+                throw new MessageDeliveryException(e.getMessage());  // StompErrorHandler에서 처리하도록
+            }
+        }
+        return message;
+
+    }
+}

--- a/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
+++ b/src/main/java/com/example/SucceSS/config/chat/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.example.SucceSS.config.chat;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +10,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @EnableWebSocketMessageBroker
 @Configuration
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final StompHandler stompHandler;
+    private final StompErrorHandler errorHandler;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -21,5 +26,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*");
+        registry.setErrorHandler(errorHandler);
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
     }
 }

--- a/src/main/java/com/example/SucceSS/config/security/JwtProvider.java
+++ b/src/main/java/com/example/SucceSS/config/security/JwtProvider.java
@@ -66,9 +66,7 @@ public class JwtProvider {
     public Authentication getAuthentication(String token) {
         // 토큰 복호화
         Claims claims = parseClaims(token);
-        if (claims.get("auth") == null) {
-            //throw new NoAuthAccessTokenException();
-        }
+
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get("auth").toString().split(","))
                         .map(SimpleGrantedAuthority::new)
@@ -90,5 +88,6 @@ public class JwtProvider {
     public Long getExpiration(String bearerToken) {
         return parseClaims(bearerToken).getExpiration().getTime()-(new Date()).getTime();
     }
+
 
 }

--- a/src/main/java/com/example/SucceSS/domain/ChatRoom.java
+++ b/src/main/java/com/example/SucceSS/domain/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.example.SucceSS.domain;
 
+import com.example.SucceSS.domain.common.BaseEntity;
 import com.example.SucceSS.web.dto.ChatRoomResponseDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatRoom {
+public class ChatRoom extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
@@ -1,10 +1,18 @@
 package com.example.SucceSS.repository;
 
 import com.example.SucceSS.domain.ChatRoom;
+import com.example.SucceSS.web.dto.ChatRoomResponseDto;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
-
+    @Query("SELECT new com.example.SucceSS.web.dto.ChatRoomResponseDto(c.chatRoomId, c.memberId, c.title) " +
+            "FROM ChatRoom c " +
+            "WHERE c.memberId = :memberId")
+    Page<ChatRoomResponseDto> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
@@ -12,7 +12,9 @@ import com.example.SucceSS.web.dto.ChatRoomResponseDto;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +57,17 @@ public class ChatRoomService {
         producer.sendMessageToUser(dto);
 
         chatRepository.save(Chat.of(dto));
+    }
+
+    public Page<ChatRoomResponseDto> getChatRoomPages(Member member, Pageable pageable) {
+        return chatRoomRepository.findByMemberId(member.getId()
+                , getChatRoomPageableWithSort(pageable));
+    }
+
+    private Pageable getChatRoomPageableWithSort(Pageable pageable) {
+        // 생각해볼 기능 : 메세지 전송 시 updatedAt 갱신하고 이를 기준으로 정렬하기 가능
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()
+                , Sort.by(Sort.Direction.ASC,"createdAt"));
     }
 
 }

--- a/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
+++ b/src/main/java/com/example/SucceSS/utils/GetCurrentUser.java
@@ -1,9 +1,11 @@
 package com.example.SucceSS.utils;
 
 import com.example.SucceSS.apiPayload.exception.MemberNotFound;
+import com.example.SucceSS.config.security.JwtProvider;
 import com.example.SucceSS.domain.Member;
 import com.example.SucceSS.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class GetCurrentUser {
 
     private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
 
     public Member getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -21,6 +24,12 @@ public class GetCurrentUser {
     }
 
     public Member getCurrentUserByAuth(Authentication auth) {
+        return memberRepository.findBySocialId(auth.getName())
+                .orElseThrow(MemberNotFound::new);
+    }
+
+    public Member getCurrentUserByAccessor(SimpMessageHeaderAccessor accessor) {
+        Authentication auth = (Authentication) accessor.getSessionAttributes().get("auth");
         return memberRepository.findBySocialId(auth.getName())
                 .orElseThrow(MemberNotFound::new);
     }

--- a/src/main/java/com/example/SucceSS/utils/JwtUtils.java
+++ b/src/main/java/com/example/SucceSS/utils/JwtUtils.java
@@ -1,0 +1,20 @@
+package com.example.SucceSS.utils;
+
+
+import com.example.SucceSS.apiPayload.exception.NoAuthorizationHeaderException;
+import com.example.SucceSS.apiPayload.exception.NoBearerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    public String extractToken(String token) {
+        if(!StringUtils.hasText(token)) throw new NoAuthorizationHeaderException();
+        if(!token.startsWith("Bearer")) throw new NoBearerException();
+
+        return token.substring(7);
+    }
+}

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -49,6 +49,13 @@ public class ChatController {
                 ApiResponse.onSuccess(chatRoomService.getChatPages(chatRoomId, pageable)));
     }
 
+    @GetMapping(value = "/rooms")
+    @Operation(summary = "채팅방 목록 불러오기")
+    public ResponseEntity<ApiResponse<Page<ChatRoomResponseDto>>> getChatRoomPages(Pageable pageable) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(chatRoomService.getChatRoomPages(getCurrentUser.getCurrentUser(), pageable)));
+    }
+
     // pub/chat/message 경로로 메세지 전송 : setApplicationDestinationPrefixes
     @MessageMapping(value = "/chat/message")
     @Operation(summary = "웹소켓 메세지 전송")

--- a/src/main/java/com/example/SucceSS/web/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/SucceSS/web/dto/ChatRoomResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.SucceSS.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +10,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChatRoomResponseDto {
     private Long chatRoomId;
     private Long memberId;
     private String title;
+    private String lastMessage;
+
+    public ChatRoomResponseDto(Long chatRoomId, Long memberId, String title) {
+        this.chatRoomId = chatRoomId;
+        this.memberId = memberId;
+        this.title = title;
+    }
 }


### PR DESCRIPTION
- 웹소켓 연결에서는 Authentication이 자동으로 주입이 안 되므로, StompHandler 등록해서 인터셉터에서 토큰에서 정보를 추출해서 세션에 저장하여 이용하도록 수정했습니다
- 첫 CONNECT 시 : Authentication 헤더에서 추출한 정보로 Authentication 만들어서 세션에 저장
- 이후 MessageMapping : SimpMessageHeaderAccessor가 주입되어 세션을 통해 현재 사용자 정보 접근 가능
- 근데 아직 StompErrorHandler를 제대로 동작이 되지 않고 있는 것 같습니다