### PR TITLE
feat/#58 채팅방 목록 조회 api에 키워드 검색 추가

### DIFF
--- a/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/SucceSS/repository/ChatRoomRepository.java
@@ -18,5 +18,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
             "WHERE c.memberId = :memberId")
     Page<ChatRoomResponseDto> getPagesByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
+    @Query("SELECT new com.example.SucceSS.web.dto.ChatRoomResponseDto(c.chatRoomId, c.memberId, c.title, c.updatedAt) " +
+            "FROM ChatRoom c " +
+            "WHERE c.memberId = :memberId " +
+            "AND c.title LIKE CONCAT('%', :keyword, '%')")
+    Page<ChatRoomResponseDto> getPagesByMemberIdAndSort(@Param("memberId") Long memberId, Pageable pageable,@Param("keyword") String keyword);
+
     Optional<ChatRoom> findByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/example/SucceSS/service/ChatService/ChatRoomService.java
@@ -57,9 +57,10 @@ public class ChatRoomService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChatRoomResponseDto> getChatRoomPages(Member member, Pageable pageable) {
-        return chatRoomRepository.getPagesByMemberId(member.getId()
-                , getChatRoomPageableWithSort(pageable));
+    public Page<ChatRoomResponseDto> getChatRoomPages(Member member, Pageable pageable, String keyword) {
+        Pageable sortedPageable = getChatRoomPageableWithSort(pageable);
+        return keyword == null ? chatRoomRepository.getPagesByMemberId(member.getId(),sortedPageable )
+                : chatRoomRepository.getPagesByMemberIdAndSort(member.getId(),sortedPageable, keyword);
     }
 
     private Pageable getChatRoomPageableWithSort(Pageable pageable) {

--- a/src/main/java/com/example/SucceSS/web/controller/ChatController.java
+++ b/src/main/java/com/example/SucceSS/web/controller/ChatController.java
@@ -53,9 +53,10 @@ public class ChatController {
 
     @GetMapping(value = "/rooms")
     @Operation(summary = "채팅방 목록 불러오기")
-    public ResponseEntity<ApiResponse<Page<ChatRoomResponseDto>>> getChatRoomPages(Pageable pageable) {
+    public ResponseEntity<ApiResponse<Page<ChatRoomResponseDto>>> getChatRoomPages(Pageable pageable
+            , @RequestParam(required = false, name = "keyword") String keyword) {
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(chatRoomService.getChatRoomPages(getCurrentUser.getCurrentUser(), pageable)));
+                ApiResponse.onSuccess(chatRoomService.getChatRoomPages(getCurrentUser.getCurrentUser(), pageable, keyword)));
     }
 
 


### PR DESCRIPTION
### 수정사항
![image](https://github.com/user-attachments/assets/e96fadd6-2124-4f93-bf60-08444ec545fa)
```"content": [
      {
        "chatRoomId": 118,
        "memberId": 1,
        "title": "잘하고 있는지 모르겠어",
        "lastMessageDate": "2025-02-25T23:46:53.387Z"
      },
      {
        "chatRoomId": 73,
        "memberId": 1,
        "title": "잘하고 있는지 모르겠어",
        "lastMessageDate": "2025-02-25T23:45:41.087Z"
      }
    ]
```

다음과 같이 채팅방 목록을 조회하는 api에 required=false인 keyword를 추가하면
채팅방 제목에 해당 키워드를 포함하는 목록만 조회하는 기능을 추가합니다

### ISSUE
resolved #62 
